### PR TITLE
Allow Showcase Player to accept config object as well as configLocation

### DIFF
--- a/js/core/services/configResolver.service.js
+++ b/js/core/services/configResolver.service.js
@@ -44,6 +44,12 @@
 
             if (!configPromise) {
 
+                if (typeof window.config === "object") {
+                    return $q.resolve(getConfigComplete({
+                        data: window.config
+                    }));
+                }
+
                 configPromise = $http
                     .get(window.configLocation)
                     .then(getConfigComplete)

--- a/js/core/services/configResolver.service.js
+++ b/js/core/services/configResolver.service.js
@@ -44,7 +44,7 @@
 
             if (!configPromise) {
 
-                if (typeof window.config === "object") {
+                if (angular.isObject(window.config)) {
                     return $q.resolve(getConfigComplete({
                         data: window.config
                     }));


### PR DESCRIPTION
### Changes proposed in this pull request:

I need to integrate the Showcase player in a store front environment where the configured playlists will be dynamically generated based on the customer's purchased content. I need to be able to supply the (dynamic) configuration object itself to the player, not a path to the configuration. 

