### PR TITLE
Feature/add options to use native scrolling and disable header

### DIFF
--- a/js/core/core.module.js
+++ b/js/core/core.module.js
@@ -122,6 +122,10 @@
                         document.body.classList.add('jw-hide-header');
                     }
 
+                    if (config.hasOwnProperty('enableJsScroll')) {
+                        $ionicConfigProvider.scrolling.jsScrolling(config.enableJsScroll);
+                    }
+
                     promises.push(api.getPlayer(config.player));
 
                     if (config.featuredPlaylist) {

--- a/js/core/core.module.js
+++ b/js/core/core.module.js
@@ -118,11 +118,11 @@
                         document.body.style.backgroundColor = config.backgroundColor;
                     }
 
-                    if (!config.enableHeader) {
+                    if (false === config.enableHeader) {
                         document.body.classList.add('jw-hide-header');
                     }
 
-                    if (config.hasOwnProperty('enableJsScroll')) {
+                    if (angular.isDefined(config.enableJsScroll)) {
                         $ionicConfigProvider.scrolling.jsScrolling(config.enableJsScroll);
                     }
 

--- a/js/core/core.module.js
+++ b/js/core/core.module.js
@@ -118,6 +118,10 @@
                         document.body.style.backgroundColor = config.backgroundColor;
                     }
 
+                    if (!config.enableHeader) {
+                        document.body.classList.add('jw-hide-header');
+                    }
+
                     promises.push(api.getPlayer(config.player));
 
                     if (config.featuredPlaylist) {

--- a/js/jwShowcase.module.js
+++ b/js/jwShowcase.module.js
@@ -31,7 +31,8 @@
             'jwShowcase.video'
         ])
         .value('config', {
-            enableContinueWatching: true
+            enableContinueWatching: true,
+            enableHeader:           true
         })
         .decorator('$controller', $controllerDecorator)
         .constant('LIB_VERSION', '3.0.0');

--- a/scss/components/_jwHeader.scss
+++ b/scss/components/_jwHeader.scss
@@ -4,6 +4,7 @@
 
 .jw-header {
     position: fixed;
+    top: 0;
     width: 100vw;
     height: $header-height;
     padding: $header-padding;
@@ -114,7 +115,6 @@
 // Subheader
 //
 .jw-header.jw-subheader {
-    top: $header-height;
     height: $subheader-height;
     min-height: $subheader-height;
     padding-top: 0;
@@ -163,14 +163,6 @@
     }
 }
 
-.platform-ios.platform-cordova .jw-header {
-    top: $ios-statusbar-height;
-
-    &.jw-subheader {
-        top: $header-height + $ios-statusbar-height;
-    }
-}
-
 //
 // mediaQueries
 // --------------------------------
@@ -204,30 +196,21 @@
         .jw-header-nav .jw-button-label {
             display: none;
         }
-    }
-
-    .jw-header.jw-subheader {
-        top: $header-height-mobile + $ios-statusbar-height;
-    }
-
-    .platform-ios.platform-cordova .jw-header {
-        top: $ios-statusbar-height;
 
         &.jw-subheader {
-            top: $header-height-mobile + $ios-statusbar-height;
+            top: $header-height-mobile;
         }
     }
 
     //
     // Mobile screen size uses a different header height so the scroll content needs to be changed also
     //
-    .platform-ios.platform-cordova:not(.fullscreen) .scroll-content,
     .scroll-content {
-        &.has-header {
+        &.has-jw-header {
             top: $header-height-mobile;
         }
 
-        &.has-subheader {
+        &.has-jw-subheader {
             top: $header-height-mobile + $subheader-height;
         }
     }
@@ -255,6 +238,20 @@
         &-video .jw-header-nav:first-child .jw-button {
             margin-left: -$header-padding;
         }
+
+        &.jw-subheader {
+            top: $header-height;
+        }
+    }
+
+    .scroll-content {
+        &.has-jw-header {
+            top: $header-height;
+        }
+
+        &.has-jw-subheader {
+            top: $header-height + $subheader-height;
+        }
     }
 }
 
@@ -266,5 +263,24 @@
             max-width: $container-width-desktop;
             margin: 0 auto;
         }
+    }
+}
+
+//
+// .jw-hide-header
+// --------------------------------
+
+.jw-hide-header {
+
+    .jw-subheader {
+        top: 0;
+    }
+
+    .scroll-content.has-jw-subheader {
+        top: $subheader-height;
+    }
+
+    .scroll-content.has-jw-header {
+        top: 0;
     }
 }

--- a/views/core/menu.html
+++ b/views/core/menu.html
@@ -5,7 +5,7 @@
     </div>
     <div class="jw-header-nav"></div>
   </jw-header>
-  <ion-content class="has-header">
+  <ion-content class="has-header" overflow-scroll="false">
 
     <div class="jw-menu-list">
 

--- a/views/core/root.html
+++ b/views/core/root.html
@@ -1,4 +1,4 @@
-<jw-header class="jw-header-full">
+<jw-header class="jw-header-full" ng-if="rootVm.config.enableHeader">
   <div class="jw-header-nav">
     <jw-header-menu-button></jw-header-menu-button>
   </div>

--- a/views/dashboard/dashboard.html
+++ b/views/dashboard/dashboard.html
@@ -1,5 +1,5 @@
 <ion-view>
-  <ion-content class="has-header">
+  <ion-content class="has-jw-header">
 
     <div class="featured">
       <div class="jw-row is-hidden-mobile" ng-if="vm.dataStore.featuredFeed">

--- a/views/feed/feed.html
+++ b/views/feed/feed.html
@@ -9,7 +9,7 @@
     <div class="jw-header-nav"></div>
   </jw-header>
 
-  <ion-content class="has-subheader">
+  <ion-content class="has-jw-subheader">
 
     <h3 class="jw-meta-feed-title" ng-if="!vm.feed.playlist.length">No videos to display</h3>
 

--- a/views/search/search.html
+++ b/views/search/search.html
@@ -9,7 +9,7 @@
     <div class="jw-header-nav"></div>
   </jw-header>
 
-  <ion-content class="has-subheader">
+  <ion-content class="has-jw-subheader">
 
     <h3 class="jw-meta-feed-title" ng-if="!vm.feed.playlist.length">
       Nothing could be found, try changing your search phrase

--- a/views/video/video.html
+++ b/views/video/video.html
@@ -1,5 +1,5 @@
 <ion-view class="jw-video-view" cache-view="false" can-swipe-back="false">
-  <ion-content class="has-header">
+  <ion-content class="has-jw-header">
 
     <div class="jw-video-container" ng-class="{'is-loading': vm.loading}">
       <div class="jw-container">


### PR DESCRIPTION
### Changes proposed in this pull request:

Adds option to use native scrolling instead of JS scrolling.

JS scrolling is problematic when integrating into an existing site since the scrolling div height needs to be managed by the site css.

In order to prevent a merge conflict, this branch also includes the changes in feature/add-option-to-hide-header from @ChristiaanScheermeijer