### PR TITLE
Add featured cards for mobile devices

### DIFF
--- a/js/dashboard/controllers/dashboard.controller.js
+++ b/js/dashboard/controllers/dashboard.controller.js
@@ -16,6 +16,8 @@
 
 (function () {
 
+    var MOBILE_SCREEN = window.matchMedia('(max-device-width: 767px)').matches;
+
     angular
         .module('jwShowcase.dashboard')
         .controller('DashboardController', DashboardController);
@@ -39,6 +41,7 @@
         vm.dataStore             = dataStore;
         vm.userSettings          = userSettings;
         vm.showWatchProgressFeed = showWatchProgressFeed;
+        vm.isMobileScreen        = MOBILE_SCREEN;
 
         vm.cardClickHandler = cardClickHandler;
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -81,7 +81,7 @@ body {
         text-decoration: none;
     }
 
-    .featured .jw-row:not(:last-child):not(:first-child) {
+    .featured .jw-row:not(:last-child) {
         margin-bottom: 8px;
     }
 }

--- a/views/dashboard/dashboard.html
+++ b/views/dashboard/dashboard.html
@@ -2,15 +2,14 @@
   <ion-content class="has-header">
 
     <div class="featured">
-      <div class="jw-row is-hidden-mobile" ng-if="vm.dataStore.featuredFeed">
+      <div class="jw-row" ng-if="vm.dataStore.featuredFeed && !vm.isMobileScreen">
         <jw-card-slider feed="vm.dataStore.featuredFeed" spacing="0" featured="true" cols="1"
             on-card-click="vm.cardClickHandler"></jw-card-slider>
       </div>
 
-      <!--<div class="jw-row is-visible-mobile" ng-repeat="item in vm.dataStore.featuredFeed.playlist">-->
-      <!--<jw-card class="is-active" item="item" featured="true" show-title="true" show-description="true"-->
-      <!--on-click="vm.cardClickHandler"></jw-card>-->
-      <!--</div>-->
+      <div class="jw-row" ng-repeat="item in vm.dataStore.featuredFeed.playlist" ng-if="vm.isMobileScreen">
+        <jw-card class="is-active" item="item" featured="true" on-click="vm.cardClickHandler"></jw-card>
+      </div>
     </div>
 
     <div class="watchProgress jw-expand-animation" ng-if="vm.showWatchProgressFeed()">


### PR DESCRIPTION
### Changes proposed in this pull request:

The CSS media queries have been replaced with ngIf directives and an one-time-only media query. This prevents the featured slider and featured cards from getting rendered while only one is being shown.

The only drawback is that it doesn't respond to screen resizes but uses the actual device width.
