### PR TITLE
Feature/add missing feed card slider

### DIFF
--- a/js/core/directives/cardSlider.directive.js
+++ b/js/core/directives/cardSlider.directive.js
@@ -75,7 +75,6 @@
 
             var sliderList             = findElements('.jw-card-slider-list'),
                 resizeHandlerDebounced = utils.debounce(resizeHandler, 100),
-                dummySlideTemplate     = $templateCache.get('views/core/cardSliderDummySlide.html'),
                 slideTemplate          = $templateCache.get('views/core/cardSliderSlide.html'),
                 index                  = 0,
                 leftSlidesVisible      = false,
@@ -127,7 +126,7 @@
 
                 if (loading) {
                     element.addClass('jw-card-slider-flag-loading');
-                    renderDummySlides();
+                    renderLoadingSlides();
                 }
 
                 resizeHandler();
@@ -167,7 +166,7 @@
              */
             function feedUpdateHandler (newValue, oldValue) {
 
-                if (comparePlaylist(newValue.playlist, oldValue.playlist)) {
+                if (!feedHasChanged(newValue, oldValue)) {
                     return;
                 }
 
@@ -182,6 +181,23 @@
                 resizeHandler(true);
             }
 
+            /**
+             * Returns true if the feeds has changed and needs to re render
+             * @param {jwShowcase.core.feed} newValue
+             * @param {jwShowcase.core.feed} oldValue
+             * @returns {boolean}
+             */
+            function feedHasChanged (newValue, oldValue) {
+
+                return !comparePlaylist(newValue.playlist, oldValue.playlist) || !!newValue.error;
+            }
+
+            /**
+             * Compare the two given playlists on their $key property
+             * @param {jwShowcase.core.item[]} playlist
+             * @param {jwShowcase.core.item[]} prevPlaylist
+             * @returns {boolean}
+             */
             function comparePlaylist (playlist, prevPlaylist) {
 
                 var playlistMap     = playlist.map(function (item) {
@@ -220,22 +236,36 @@
                 findElements('.jw-card-slider-button').toggleClass('ng-hide', !sliderCanSlide);
 
                 if (forceRender || needsRender) {
-                    renderSlides();
+
+                    if (scope.vm.feed.error) {
+                         renderErrorSlides();
+                    }
+                    else if (scope.vm.feed.loading) {
+                        renderLoadingSlides();
+                    }
+                    else {
+                        renderSlides();
+                    }
                 }
 
                 moveSlider(0, false);
             }
 
             /**
-             * Render dummy slides
+             * Render custom slides
+             * @param {string} templateUrl
+             * @parma {number} count
              */
-            function renderDummySlides () {
+            function renderCustomSlides (templateUrl, count) {
 
                 var holder = angular.element('<div></div>'),
+                    template = $templateCache.get(templateUrl),
                     dummy;
 
-                for (var i = 0; i < 5; i++) {
-                    dummy = angular.element(dummySlideTemplate);
+                count = count || 5;
+
+                for (var i = 0; i < count; i++) {
+                    dummy = angular.element(template);
                     dummy.children().eq(0).addClass('jw-card-flag-' + (scope.vm.featured ? 'featured' : 'default'));
                     holder.append(dummy);
                 }
@@ -243,6 +273,28 @@
                 sliderList
                     .html('')
                     .append(holder.children());
+            }
+
+            /**
+             * Render loading slides
+             */
+            function renderLoadingSlides () {
+
+                renderCustomSlides('views/core/cardSliderDummySlide.html', 6);
+
+                element.addClass('jw-card-slider-flag-loading');
+            }
+
+            /**
+             * Render error slides
+             */
+            function renderErrorSlides () {
+
+                renderCustomSlides('views/core/cardSliderErrorSlide.html', 6);
+
+                scope.vm.heading = 'Missing feed';
+
+                element.addClass('jw-card-slider-flag-error');
             }
 
             /**
@@ -259,10 +311,6 @@
                 if (leftSlidesVisible) {
                     itemIndex -= itemsMargin;
                     totalCols += itemsMargin;
-                }
-
-                if (scope.vm.feed.loading) {
-                    return renderDummySlides();
                 }
 
                 if (itemIndex < 0) {

--- a/js/core/services/apiConsumer.service.js
+++ b/js/core/services/apiConsumer.service.js
@@ -80,6 +80,15 @@
                     return feed;
                 });
 
+                feed.promise.catch(function (error) {
+
+                    feed.error = error;
+                    feed.loading = false;
+                    feed.navigable = false;
+
+                    return feed;
+                });
+
                 return feed.promise;
             }
 

--- a/js/core/services/dataStore.service.js
+++ b/js/core/services/dataStore.service.js
@@ -60,7 +60,7 @@
          * @description
          * The watchlist feed
          */
-        this.watchlistFeed = new FeedModel('saved-videos', 'Saved videos');
+        this.watchlistFeed = new FeedModel('saved-videos', 'Saved videos', false);
 
         /**
          * @ngdoc property
@@ -71,7 +71,7 @@
          * @description
          * The watchProgress feed
          */
-        this.watchProgressFeed = new FeedModel('continue-watching', 'Continue watching');
+        this.watchProgressFeed = new FeedModel('continue-watching', 'Continue watching', false);
 
         /**
          * @ngdoc method

--- a/js/core/services/feedModel.service.js
+++ b/js/core/services/feedModel.service.js
@@ -27,7 +27,7 @@
     feedModelFactory.$inject = [];
     function feedModelFactory () {
 
-        function FeedModel (feedId, title) {
+        function FeedModel (feedId, title, navigable) {
 
             this.feedid = feedId;
 
@@ -35,7 +35,11 @@
 
             this.playlist = [];
 
+            this.navigable = navigable || true;
+
             this.loading = false;
+
+            this.error = false;
 
             /**
              * Find item inside this feed

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -58,8 +58,14 @@ $desktop-min-width: $tablet-max-width + 1 !default;
 // Themes
 // --------------------------------
 
-$theme-light-bg-color: #d7dbe6;
-$theme-dark-bg-color: #363636;
+$theme-light-bg-color: #d7dbe6 !default;
+$theme-dark-bg-color: #363636 !default;
+
+$theme-light-slider-slide-loading-bg-color: #979797 !default;
+$theme-dark-slider-slide-loading-bg-color: #1a1a1a !default;
+
+$theme-light-slider-title-error-color: #979797 !default;
+$theme-dark-slider-title-error-color: #979797 !default;
 
 //
 // Header

--- a/scss/components/_jwCardSlider.scss
+++ b/scss/components/_jwCardSlider.scss
@@ -269,11 +269,11 @@ $featured-slider-max-width: 900px;
             pointer-events: none;
         }
 
-        &-flag-dummy {
-            background: $white;
+        &-flag-error {
+            opacity: 1;
 
-            .jw-card-aspect {
-                background: $main-color;
+            .jw-card-controls {
+                opacity: 1;
             }
         }
     }

--- a/scss/themes/_dark.scss
+++ b/scss/themes/_dark.scss
@@ -22,12 +22,41 @@
         color: $white;
     }
 
-    .jw-card-slider.jw-card-slider-flag-default {
-        border-bottom: 1px solid darken($dark-color, 5%);
-    }
+    .jw-card-slider {
 
-    .jw-card-slider .jw-card-slider-button {
-        color: $white;
+        &-flag-default {
+            border-bottom: 1px solid darken($dark-color, 5%);
+        }
+
+        &-flag-error {
+            .jw-card-slider-title .jw-link,
+            .jw-card-slider-title > div {
+                color: $theme-dark-slider-title-error-color;
+            }
+        }
+
+        .jw-card-slider-button {
+            color: $white;
+        }
+
+        .jw-card-slider-slide {
+
+            &-flag-loading {
+                background: $black;
+
+                .jw-card-aspect {
+                    background: $main-color;
+                }
+            }
+
+            &-flag-error {
+                background: $black;
+
+                .jw-card-aspect {
+                    background: $theme-dark-slider-slide-loading-bg-color;
+                }
+            }
+        }
     }
 
     .jw-card-slider-title .jw-link,

--- a/scss/themes/_light.scss
+++ b/scss/themes/_light.scss
@@ -26,12 +26,38 @@
 
     .jw-card-slider {
 
-        &.jw-card-slider-flag-default {
+        &-flag-default {
             border-bottom: 1px solid rgba($main-color, 0.2);
         }
 
-        &.jw-card-slider-flag-default.jw-card-slider-button {
+        &-flag-default.jw-card-slider-button {
             color: $black;
+        }
+
+        &-flag-error {
+            .jw-card-slider-title .jw-link,
+            .jw-card-slider-title > div {
+                color: $theme-light-slider-title-error-color;
+            }
+        }
+
+        .jw-card-slider-slide {
+
+            &-flag-loading {
+                background: $white;
+
+                .jw-card-aspect {
+                    background: $main-color;
+                }
+            }
+
+            &-flag-error {
+                background: $white;
+
+                .jw-card-aspect {
+                    background: $theme-light-slider-slide-loading-bg-color;
+                }
+            }
         }
     }
 

--- a/views/core/cardSlider.html
+++ b/views/core/cardSlider.html
@@ -1,10 +1,14 @@
 <div class="jw-card-slider">
   <div class="jw-card-slider-container">
     <div class="jw-card-slider-title">
-      <a ui-sref="root.feed({feedId: vm.feed.feedid})" class="jw-link">
+      <a ui-sref="root.feed({feedId: vm.feed.feedid})" class="jw-link" ng-if="vm.feed.navigable">
         <span>{{ vm.heading }}&nbsp;</span> <i class="jwy-icon jwy-icon-angle-right"></i> <span
           class="jw-card-slider-title-count">({{ vm.feed.playlist.length }})</span>
       </a>
+      <div ng-if="!vm.feed.navigable">
+        <span>{{ vm.heading }}&nbsp;</span> <span class="jw-card-slider-title-count"
+      ng-if="vm.feed.playlist.length">({{ vm.feed.playlist.length }})</span>
+      </div>
     </div>
     <div class="jw-card-slider-align">
       <div class="jw-card-slider-list"></div>

--- a/views/core/cardSliderErrorSlide.html
+++ b/views/core/cardSliderErrorSlide.html
@@ -1,0 +1,13 @@
+<div class="jw-card-slider-slide jw-card-slider-slide-flag-error">
+  <div class="jw-card">
+    <div class="jw-card-aspect"></div>
+    <div class="jw-card-container">
+      <div class="jw-card-controls">
+        <div class="jw-card-controls-align">
+          <div class="jw-card-text">Can't show video</div>
+        </div>
+      </div>
+      <div class="jw-card-info"></div>
+    </div>
+  </div>
+</div>

--- a/views/core/cardSliderLoadingSlide.html
+++ b/views/core/cardSliderLoadingSlide.html
@@ -1,4 +1,4 @@
-<div class="jw-card-slider-slide jw-card-slider-slide-flag-dummy">
+<div class="jw-card-slider-slide jw-card-slider-slide-flag-loading">
   <div class="jw-card">
     <div class="jw-card-aspect"></div>
   </div>


### PR DESCRIPTION
### Changes proposed in this pull request:

Because the feeds are now loaded asynchronous the user and admin aren't informed when a feed fails to load. As an improvement Showcase is usable instead of showing an overlay with the error message. This feature adds a 'Missing feed' shelve to inform the user and admin something went wrong.

![image](https://cloud.githubusercontent.com/assets/3996119/23063626/d6944ff2-f50b-11e6-8287-21f7f99971a4.png)
