### PR TITLE
Fix title in jwplayer appearing in some browsers

### DIFF
--- a/scss/components/_jwPlayer.scss
+++ b/scss/components/_jwPlayer.scss
@@ -36,6 +36,7 @@
 // http://stackoverflow.com/a/29780590
 video::-internal-media-controls-overlay-cast-button {
     display: none;
+    visibility: hidden;
 }
 // scss-lint:enable PseudoElement
 


### PR DESCRIPTION
### Changes proposed in this pull request:

Because the 'video::-internal-media-controls-overlay-cast-button' selector was merged with multiple selectors, none of them worked when it was not supported
