### PR TITLE
Add check to test if item.tracks is an array

### DIFF
--- a/js/core/directives/cardPoster.directive.js
+++ b/js/core/directives/cardPoster.directive.js
@@ -69,10 +69,12 @@
 
                 itemPosterUrl = generatePosterUrl();
 
-                // in the old feed api the kind is called `thumbnails` while the new feed api uses `thumbnail`.
-                thumbnailsTrack = jwCard.item.tracks.find(function (track) {
-                    return track.kind === 'thumbnails' || track.kind === 'thumbnail';
-                });
+                if (angular.isArray(jwCard.item.tracks)) {
+                    // in the old feed api the kind is called `thumbnails` while the new feed api uses `thumbnail`.
+                    thumbnailsTrack = jwCard.item.tracks.find(function (track) {
+                        return track.kind === 'thumbnails' || track.kind === 'thumbnail';
+                    });
+                }
 
                 if (jwCard.featured) {
 


### PR DESCRIPTION
### Changes proposed in this pull request:

While thumbnails are being generated (and no captions are added) the `item.tracks` property is null. There was an error thrown by the cardPoster directive.
