### PR TITLE
Feature/add use recommendation playlist option

### DIFF
--- a/js/core/directives/cardSlider.directive.js
+++ b/js/core/directives/cardSlider.directive.js
@@ -38,6 +38,7 @@
      * @param {jwShowcase.core.feed}    feed            Feed which will be displayed in the slider.
      * @param {boolean=}                featured        Featured slider flag
      * @param {function=}               onCardClick     Function which is being called when the user clicks on a card.
+     * @param {jwShowcase.core.item}    firstItem       Item which should be shown first.
      * @param {string=}                 title           Overrule title from {@link jwShowcase.core.feed}
      *
      * @requires $state
@@ -60,6 +61,7 @@
                 feed:        '=',
                 featured:    '=',
                 onCardClick: '=',
+                firstItem:   '=',
                 title:       '@'
             },
             replace:          true,
@@ -111,9 +113,12 @@
                 window.addEventListener('resize', resizeHandlerDebounced);
                 findElement('.jw-card-slider-align')[0].addEventListener('touchstart', onTouchStart, false);
 
-                scope.$watch(function () {
-                    return scope.vm.feed;
-                }, feedUpdateHandler, true);
+                scope.$watch('vm.feed', feedUpdateHandler, true);
+                scope.$watch('vm.firstItem', function (firstItem) {
+                    if (firstItem) {
+                        resizeHandler(true);
+                    }
+                }, true);
 
                 if (scope.vm.feed) {
                     totalItems = scope.vm.feed.playlist.length;
@@ -326,8 +331,19 @@
              */
             function renderSlides () {
 
-                var nextSliderMap = [],
+                var playlist = scope.vm.feed.playlist,
+                    nextSliderMap = [],
                     nextSliderList;
+
+                if (scope.vm.firstItem) {
+                    var firstItemIndex = scope.vm.feed.playlist.findIndex(function (item) {
+                        return item.mediaid === scope.vm.firstItem.mediaid;
+                    });
+
+                    playlist = playlist
+                        .slice(firstItemIndex)
+                        .concat(playlist.slice(0, firstItemIndex));
+                }
 
                 // create visible slides first so these will be used from the cache with priority. E.g. prevents render
                 // of visible cards.
@@ -382,7 +398,7 @@
                             itemIndex = 0;
                         }
 
-                        item  = scope.vm.feed.playlist[itemIndex];
+                        item  = playlist[itemIndex];
                         slide = findExistingSlide(item, visible) || createSlide(item);
 
                         addClassNamesToSlide(slide, itemIndex, visible);

--- a/js/jwShowcase.module.js
+++ b/js/jwShowcase.module.js
@@ -33,15 +33,16 @@
         .value('config', {
             contentService: 'https://content.jwplatform.com',
             options:        {
-                enableContinueWatching: true,
-                enableCookieNotice:     false,
-                enableFeaturedText:     true,
-                enablePlayerAutoFocus:  true,
-                enableHeader:           true,
-                enableTags:             false,
-                rightRail: {
+                enableContinueWatching:    true,
+                enableCookieNotice:        false,
+                enableFeaturedText:        true,
+                enablePlayerAutoFocus:     true,
+                enableHeader:              true,
+                enableTags:                false,
+                rightRail:                 {
                     enabled: false
-                }
+                },
+                useRecommendationPlaylist: false
             }
         });
 

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -28,8 +28,6 @@
      * @requires $state
      * @requires $stateParams
      * @requires $timeout
-     * @requires jwShowcase.core.apiConsumer
-     * @requires jwShowcase.core.FeedModel
      * @requires jwShowcase.core.dataStore
      * @requires jwShowcase.core.popup
      * @requires jwShowcase.core.watchProgress
@@ -42,29 +40,46 @@
      * @requires jwShowcase.core.serviceWorker
      * @requires jwShowcase.config
      */
-    VideoController.$inject = ['$scope', '$state', '$stateParams', '$timeout', 'apiConsumer', 'FeedModel', 'dataStore',
-        'popup', 'watchProgress', 'watchlist', 'seo', 'userSettings', 'utils', 'player', 'platform', 'serviceWorker',
-        'config', 'feed', 'item'];
-    function VideoController ($scope, $state, $stateParams, $timeout, apiConsumer, FeedModel, dataStore, popup,
+    VideoController.$inject = ['$scope', '$state', '$stateParams', '$timeout', 'dataStore', 'popup', 'watchProgress',
+        'watchlist', 'seo', 'userSettings', 'utils', 'player', 'platform', 'serviceWorker', 'config', 'feed', 'item',
+        'recommendations'];
+    function VideoController ($scope, $state, $stateParams, $timeout, dataStore, popup,
                               watchProgress, watchlist, seo, userSettings, utils, player, platform, serviceWorker,
-                              config, feed, item) {
+                              config, feed, item, recommendations) {
 
-        var vm                     = this,
-            lastPos                = 0,
-            resumed                = false,
-            started                = false,
-            requestQualityChange   = false,
-            itemFeed               = feed,
-            loadingRecommendations = false,
-            playerPlaylist         = [],
-            playerLevels,
+        var vm                   = this,
+            lastPos              = 0,
+            resumed              = false,
+            started              = false,
+            requestQualityChange = false,
+            playlist             = [],
+            levels,
             watchProgressItem,
             loadingTimeout;
 
-        vm.item                = item;
-        vm.feed                = feed.clone();
-        vm.recommendationsFeed = null;
-        vm.loading             = true;
+        /**
+         * Current playing item
+         * @type {jwShowcase.core.item}
+         */
+        vm.item = item;
+
+        /**
+         * Loading flag
+         * @type {boolean}
+         */
+        vm.loading = true;
+
+        /**
+         * Feed which is being used as playlist for the player.
+         * @type {jwShowcase.core.feed}
+         */
+        vm.activeFeed = null;
+
+        /**
+         * Additional feed which can be recommendations or the item feed.
+         * @type {jwShowcase.core.feed}
+         */
+        vm.extraFeed = null;
 
         vm.onComplete     = onComplete;
         vm.onFirstFrame   = onFirstFrame;
@@ -87,7 +102,9 @@
          */
         function activate () {
 
-            playerPlaylist = generatePlaylist(itemFeed, item);
+            updateFeeds();
+
+            playlist = generatePlaylist(vm.activeFeed, item);
 
             vm.playerSettings = {
                 width:          '100%',
@@ -95,7 +112,7 @@
                 aspectratio:    '16:9',
                 ph:             4,
                 autostart:      $state.params.autoStart,
-                playlist:       playerPlaylist,
+                playlist:       playlist,
                 related:        false,
                 preload:        'metadata',
                 sharing:        false,
@@ -116,7 +133,7 @@
 
             if (!!window.cordova) {
                 vm.playerSettings.analytics.sdkplatform = platform.isAndroid ? 1 : 2;
-                vm.playerSettings.cast = false;
+                vm.playerSettings.cast                  = false;
             }
 
             $scope.$watch(function () {
@@ -128,8 +145,8 @@
             }, function () {
                 var state = player.getState();
                 if (state !== 'playing' && state !== 'paused') {
-                    playerPlaylist = generatePlaylist(itemFeed, item);
-                    player.load(playerPlaylist);
+                    playlist = generatePlaylist(vm.activeFeed, vm.item);
+                    player.load(playlist);
                     update();
                 }
             });
@@ -142,57 +159,59 @@
         }
 
         /**
+         * Update feeds
+         */
+        function updateFeeds () {
+
+            // set activeFeed pointer to the recommendations feed when useRecommendationPlaylist is true and
+            // recommendations exists
+            if (config.options.useRecommendationPlaylist && recommendations) {
+
+                // if recommendations are used for the playlist the current item must be added in order to generate the
+                // player playlist and show the 'Currently playing' item in the slider.
+                if (!recommendations.playlist.find(byMediaId(vm.item.mediaid))) {
+                    recommendations.playlist.unshift(vm.item);
+                }
+
+                vm.activeFeed = recommendations;
+                vm.extraFeed  = feed;
+
+                return;
+            }
+
+            // by default use the feed playlist as activeFeed and show the recommendations feed below
+            vm.activeFeed = feed;
+            vm.extraFeed  = recommendations;
+        }
+
+        /**
          * Update controller
          */
         function update () {
 
-            var itemIndex = itemFeed.playlist.findIndex(byMediaId(vm.item.mediaid));
-
-            vm.feed.playlist = itemFeed.playlist
-                .slice(itemIndex)
-                .concat(itemFeed.playlist.slice(0, itemIndex));
-
             watchProgressItem = watchProgress.getItem(vm.item);
-
-            if (navigator.onLine) {
-                loadRecommendations();
-            }
         }
 
-        /**
-         * Load recommendations
-         */
-        function loadRecommendations () {
+        function updateStateSilently () {
 
-            if (!config.recommendationsPlaylist) {
-                vm.recommendationsFeed = null;
-                return;
-            }
+            var stateParams = $state.params;
 
-            if (loadingRecommendations) {
-                return;
-            }
+            stateParams.mediaId = $stateParams.mediaId = vm.item.mediaid;
+            stateParams.feedId = $stateParams.feedId = vm.item.feedid;
+            stateParams.slug = $stateParams.slug = vm.item.$slug;
 
-            loadingRecommendations = true;
+            $state.$current.locals.globals.item = vm.item;
 
-            if (!vm.recommendationsFeed) {
-                vm.recommendationsFeed = new FeedModel(config.recommendationsPlaylist, 'Related Videos', false);
-            }
-
-            vm.recommendationsFeed.relatedMediaId = vm.item.mediaid;
-
-            apiConsumer
-                .populateFeedModel(vm.recommendationsFeed, 'recommendations')
-                .then(function (recommendationsFeed) {
-
-                    // filter duplicate video's
-                    if (angular.isArray(recommendationsFeed.playlist)) {
-                        recommendationsFeed.playlist = recommendationsFeed.playlist.filter(function (item) {
-                            return itemFeed.playlist.findIndex(byMediaId(item.mediaid)) === -1;
-                        });
-                    }
-
-                    loadingRecommendations = false;
+            $state
+                .go('root.video', {
+                    feedId:  vm.item.feedid,
+                    mediaId: vm.item.mediaid,
+                    slug:    vm.item.$slug
+                }, {
+                    notify: false
+                })
+                .then(function () {
+                    seo.update();
                 });
         }
 
@@ -263,11 +282,11 @@
                 toQuality = 0;
 
             // nothing to do
-            if (!playerLevels) {
+            if (!levels) {
                 return;
             }
 
-            levelsLength = playerLevels.length;
+            levelsLength = levels.length;
 
             if (true === value) {
                 toQuality = levelsLength > 2 ? levelsLength - 2 : levelsLength;
@@ -335,43 +354,23 @@
          */
         function onPlaylistItem (event) {
 
-            var playlistItem = playerPlaylist[event.index],
-                stateParams  = $state.params,
+            var playlistItem = playlist[event.index],
                 newItem;
 
             if (!angular.isNumber(event.index) || !playlistItem) {
                 return;
             }
 
-            newItem = dataStore.getItem(playlistItem.mediaid, itemFeed.feedid);
+            newItem = dataStore.getItem(playlistItem.mediaid, playlistItem.feedid);
 
-            // same item
+            // return if item doesn't exist or its the same item
             if (!newItem || newItem.mediaid === vm.item.mediaid) {
                 return;
             }
 
-            // update $viewHistory
-            stateParams.feedId  = $stateParams.feedId = newItem.feedid;
-            stateParams.mediaId = $stateParams.mediaId = newItem.mediaid;
-            stateParams.slug    = $stateParams.slug = newItem.$slug;
-
-            $state.$current.locals.globals.item = newItem;
-
-            // update state, but don't notify
-            $state
-                .go('root.video', {
-                    feedId:    newItem.feedid,
-                    mediaId:   newItem.mediaid,
-                    slug:      newItem.$slug,
-                    autoStart: true
-                }, {
-                    notify: false
-                })
-                .then(function () {
-                    seo.update();
-                });
-
             vm.item = newItem;
+
+            updateStateSilently();
             update();
         }
 
@@ -388,11 +387,11 @@
 
             started = true;
 
-            if (!playerLevels) {
+            if (!levels) {
                 return;
             }
 
-            levelsLength = playerLevels.length;
+            levelsLength = levels.length;
 
             // hd turned off
             // set quality to last lowest level
@@ -408,7 +407,7 @@
          */
         function onLevels (event) {
 
-            playerLevels = event.levels;
+            levels = event.levels;
         }
 
 
@@ -520,56 +519,33 @@
          */
         function cardClickHandler (newItem, clickedOnPlay) {
 
-            var playlistIndex = playerPlaylist.findIndex(byMediaId(newItem.mediaid)),
-                stateParams   = $state.params;
+            var playlistIndex = playlist.findIndex(byMediaId(newItem.mediaid));
 
             // same item
             if (vm.item.mediaid === newItem.mediaid) {
                 return;
             }
 
-            vm.item = angular.extend({}, newItem);
-
-            stateParams.mediaId = $stateParams.mediaId = vm.item.mediaid;
-            stateParams.feedId  = $stateParams.feedId = vm.item.feedid;
-            stateParams.slug    = $stateParams.slug = vm.item.$slug;
-
-            $state.$current.locals.globals.item = newItem;
-
-            // update playlist when item does not exist in current playlist
+            // navigate to item which is not in current playlist
             if (playlistIndex === -1) {
 
-                itemFeed = dataStore.getFeed(vm.item.feedid);
-                vm.feed  = itemFeed.clone();
-
-                $state.$current.locals.globals.feed = vm.feed;
-
-                playerPlaylist = generatePlaylist(itemFeed, vm.item);
-                player.load(playerPlaylist);
-
-                if (clickedOnPlay || platform.isMobile) {
-                    player.play(true);
-                }
-            }
-            else {
-                playlistIndex = playerPlaylist.findIndex(byMediaId(vm.item.mediaid));
-                player.playlistItem(playlistIndex);
-            }
-
-            $state
-                .go('root.video', {
-                    feedId:    vm.item.feedid,
-                    mediaId:   vm.item.mediaid,
-                    slug:      vm.item.$slug,
+                return $state.go('root.video', {
+                    feedId:    newItem.feedid,
+                    mediaId:   newItem.mediaid,
+                    slug:      newItem.$slug,
                     autoStart: clickedOnPlay
-                }, {
-                    notify: false
-                })
-                .then(function () {
-                    seo.update();
                 });
+            }
 
+            // update current item and set playlistItem
+            vm.item = angular.extend({}, newItem);
+
+            playlistIndex = playlist.findIndex(byMediaId(vm.item.mediaid));
+            player.playlistItem(playlistIndex);
+
+            updateStateSilently();
             update();
+
             window.TweenLite.to(document.scrollingElement || document.body, 0.3, {
                 scrollTop: 0
             });

--- a/views/video/video.html
+++ b/views/video/video.html
@@ -23,12 +23,24 @@
     <jw-video-details item="vm.item"></jw-video-details>
   </div>
 
-  <div class="jw-row" ng-if="vm.feed">
-    <jw-card-slider feed="vm.feed" featured="false" delegate="vm.feedCardSliderDelegate" title="More like this"
-        class="jw-card-slider-flag-now-playing jw-lazy-load" on-card-click="vm.cardClickHandler"></jw-card-slider>
+  <div class="jw-row" ng-if="vm.activeFeed">
+    <jw-card-slider
+        feed="vm.activeFeed"
+        featured="false"
+        title="Up Next"
+        class="jw-card-slider-flag-now-playing jw-lazy-load"
+        first-item="vm.item"
+        on-card-click="vm.cardClickHandler">
+    </jw-card-slider>
   </div>
-  <div class="jw-row" ng-if="vm.recommendationsFeed">
-    <jw-card-slider feed="vm.recommendationsFeed" featured="false" title="Related videos" class="jw-lazy-load"
-         on-card-click="vm.cardClickHandler"></jw-card-slider>
+
+  <div class="jw-row" ng-if="vm.extraFeed">
+    <jw-card-slider
+        feed="vm.extraFeed"
+        featured="false"
+        title="Related Videos"
+        class="jw-lazy-load"
+        on-card-click="vm.cardClickHandler">
+    </jw-card-slider>
   </div>
 </div>


### PR DESCRIPTION
### Changes proposed in this pull request:

Adds option to change the default behaviour of using the feed as player playlist. By setting `config.options.useRecommendationPlaylist` to true the recommendations playlist will be used as playlist when available. 

Side note; by this change the recommendations playlist will not update when the current item changes. The recommendations playlist is based on the initial item.
