### PR TITLE
Feat/invideo search

### DIFF
--- a/js/core/components/search.component.js
+++ b/js/core/components/search.component.js
@@ -51,13 +51,15 @@
 
         vm.config = config;
 
-        vm.searchPhrase    = '';
-        vm.searchBarActive = false;
+        vm.searchPhrase       = '';
+        vm.searchBarActive    = false;
+        vm.searchInCaptions   = false;
 
         vm.closeSearchButtonClickHandler = closeSearchButtonClickHandler;
         vm.searchButtonClickHandler      = searchButtonClickHandler;
         vm.searchInputKeyupHandler       = searchInputKeyupHandler;
         vm.searchInputChangeHandler      = searchInputChangeHandler;
+        vm.toggleSearchInCaptions        = toggleSearchInCaptions;
 
         vm.$onInit = activate;
 
@@ -149,15 +151,22 @@
             searchAndDisplayResults();
         }
 
-
         /**
          * Get search results and go to search state
          */
         function searchAndDisplayResults () {
 
             $state.go('root.search', {
-                query: utils.slugify(vm.searchPhrase, '+')
+                query: utils.slugify(vm.searchPhrase, '+'),
+                searchInCaptions: vm.searchInCaptions
             });
+        }
+
+        /**
+         *  With every toggle get new search results
+         */
+        function toggleSearchInCaptions () {
+            searchAndDisplayResults();
         }
     }
 

--- a/js/core/components/search.component.js
+++ b/js/core/components/search.component.js
@@ -45,15 +45,16 @@
      * @requires jwShowcase.config
      */
     SearchController.$inject = ['$rootScope', '$state', 'config', 'utils'];
+
     function SearchController ($rootScope, $state, config, utils) {
 
-        var vm        = this;
+        var vm = this;
 
         vm.config = config;
 
-        vm.searchPhrase       = '';
-        vm.searchBarActive    = false;
-        vm.searchInCaptions   = false;
+        vm.searchPhrase     = '';
+        vm.searchBarActive  = false;
+        vm.searchInCaptions = false;
 
         vm.closeSearchButtonClickHandler = closeSearchButtonClickHandler;
         vm.searchButtonClickHandler      = searchButtonClickHandler;
@@ -77,8 +78,9 @@
                     vm.searchBarActive = false;
                 }
                 else {
-                    vm.searchPhrase = toParams.query.replace(/\+/g, ' ');
-                    vm.searchBarActive = true;
+                    vm.searchPhrase     = toParams.query.replace(/\+/g, ' ');
+                    vm.searchBarActive  = true;
+                    vm.searchInCaptions = toParams.searchInCaptions;
                 }
             });
         }
@@ -157,7 +159,7 @@
         function searchAndDisplayResults () {
 
             $state.go('root.search', {
-                query: utils.slugify(vm.searchPhrase, '+'),
+                query:            utils.slugify(vm.searchPhrase, '+'),
                 searchInCaptions: vm.searchInCaptions
             });
         }

--- a/js/core/core.module.js
+++ b/js/core/core.module.js
@@ -30,6 +30,7 @@
 
     config.$inject = ['$stateProvider', '$urlMatcherFactoryProvider', '$touchProvider', 'seoProvider',
         'historyProvider'];
+
     function config ($stateProvider, $urlMatcherFactoryProvider, $touchProvider, seoProvider, historyProvider) {
 
         if ('ontouchstart' in window || (window.DocumentTouch && document instanceof window.DocumentTouch)) {
@@ -38,6 +39,21 @@
 
         $urlMatcherFactoryProvider
             .strictMode(false);
+
+        $urlMatcherFactoryProvider
+            .type('boolean', {
+                name:    'boolean',
+                decode:  function (val) {
+                    return val === 'true';
+                },
+                equals:  function (a, b) {
+                    return angular.equals(a, b);
+                },
+                is:      function (val) {
+                    return typeof val === 'boolean';
+                },
+                pattern: /true|false/
+            });
 
         historyProvider
             .setDefaultState('root.dashboard');
@@ -62,6 +78,7 @@
     }
 
     run.$inject = ['$document', 'history', 'platform'];
+
     function run ($document, history, platform) {
 
         history.attach();

--- a/js/core/directives/card.directive.js
+++ b/js/core/directives/card.directive.js
@@ -66,7 +66,7 @@
             var enableInVideoSearch = config.options.enableInVideoSearch;
 
             scope.vm.activeCaption       = null;
-            scope.vm.inLineSearchEnabled = enableInVideoSearch && scope.vm.item.captionMatches && isSearch;
+            scope.vm.inVideoSearchEnabled = enableInVideoSearch && scope.vm.item.captionMatches && isSearch;
 
             scope.vm.showToast              = showToast;
             scope.vm.closeMenu              = closeMenu;
@@ -105,7 +105,7 @@
 
                 var completeTitle = '';
 
-                if (scope.vm.inLineSearchEnabled) {
+                if (scope.vm.inVideoSearchEnabled) {
                     var matchCount = item.captionMatches.length;
 
                     completeTitle = '<span class="jw-card-title-matches">' + matchCount + ' matches: </span>';

--- a/js/core/directives/card.directive.js
+++ b/js/core/directives/card.directive.js
@@ -88,7 +88,6 @@
 
                 element.addClass('jw-card-flag-' + (scope.vm.featured ? 'featured' : 'default'));
 
-
                 if (feed && $state.is('root.dashboard')) {
                     enableText = feed.enableText;
                 }

--- a/js/core/directives/card.directive.js
+++ b/js/core/directives/card.directive.js
@@ -43,9 +43,9 @@
      * ```
      */
     cardDirective.$inject = ['$animate', '$q', '$state', '$timeout', '$templateCache', '$compile', 'dataStore',
-        'watchlist', 'utils', 'serviceWorker'];
+        'watchlist', 'utils', 'serviceWorker', 'config'];
     function cardDirective ($animate, $q, $state, $timeout, $templateCache, $compile, dataStore, watchlist, utils,
-                            serviceWorker) {
+                            serviceWorker, config) {
 
         return {
             scope:            {
@@ -62,11 +62,15 @@
         };
 
         function link (scope, element) {
+            scope.vm.inLineSearchEnabled = config.options.enableInVideoSearch && scope.vm.item.captionMatches;
+            scope.vm.activeCaption       = null;
 
             scope.vm.showToast              = showToast;
             scope.vm.closeMenu              = closeMenu;
             scope.vm.menuButtonClickHandler = menuButtonClickHandler;
             scope.vm.containerClickHandler  = containerClickHandler;
+            scope.vm.setActiveCaption       = setActiveCaption;
+            scope.vm.removeActiveCaption    = removeActiveCaption;
 
             activate();
 
@@ -75,10 +79,12 @@
             function activate () {
 
                 var feed       = dataStore.getFeed(scope.vm.item.feedid),
+                    item       = scope.vm.item,
                     enableText = true,
                     link       = generateLink();
 
                 element.addClass('jw-card-flag-' + (scope.vm.featured ? 'featured' : 'default'));
+
 
                 if (feed && $state.is('root.dashboard')) {
                     enableText = feed.enableText;
@@ -93,25 +99,35 @@
                 }
 
                 findElement('.jw-card-container')
-                    .attr('aria-label', 'play video ' + scope.vm.item.title);
+                    .attr('aria-label', 'play video ' + item.title);
+
+                var completeTitle = '';
+
+                if (scope.vm.inLineSearchEnabled) {
+                    var matchCount = item.captionMatches.length;
+
+                    completeTitle = '<span class="jw-card-title-matches">' + matchCount + ' matches: </span>';
+                }
+
+                completeTitle += item.title;
 
                 findElement('.jw-card-title')
-                    .html(scope.vm.item.title)
+                    .html(completeTitle)
                     .attr('href', link)
                     .on('click', titleClickHandler);
 
                 findElement('.jw-card-duration')
-                    .html(utils.getVideoDurationByItem(scope.vm.item));
+                    .html(utils.getVideoDurationByItem(item));
 
                 // set watch progress
-                if (scope.vm.item.feedid === 'continue-watching') {
+                if (item.feedid === 'continue-watching') {
                     scope.$watch('vm.item.progress', watchProgressUpdateHandler);
                 }
 
                 scope.$on('$destroy', destroyDirectiveHandler);
 
                 scope.$watch(function () {
-                    return watchlist.hasItem(scope.vm.item);
+                    return watchlist.hasItem(item);
                 }, watchlistUpdateHandler);
             }
 
@@ -178,6 +194,14 @@
             function titleClickHandler (event) {
 
                 event.preventDefault();
+            }
+
+            function setActiveCaption (caption) {
+                scope.vm.activeCaption = caption;
+            }
+
+            function removeActiveCaption () {
+                scope.vm.activeCaption = null;
             }
 
             /**

--- a/js/core/directives/card.directive.js
+++ b/js/core/directives/card.directive.js
@@ -62,8 +62,11 @@
         };
 
         function link (scope, element) {
-            scope.vm.inLineSearchEnabled = config.options.enableInVideoSearch && scope.vm.item.captionMatches;
+            var isSearch            = $state.is('root.search');
+            var enableInVideoSearch = config.options.enableInVideoSearch;
+
             scope.vm.activeCaption       = null;
+            scope.vm.inLineSearchEnabled = enableInVideoSearch && scope.vm.item.captionMatches && isSearch;
 
             scope.vm.showToast              = showToast;
             scope.vm.closeMenu              = closeMenu;
@@ -197,24 +200,30 @@
             }
 
             function setActiveCaption (caption) {
+                scope.$broadcast('caption_changed', {caption: caption, thumbnails: scope.vm.item.thumbnails});
+
                 scope.vm.activeCaption = caption;
             }
 
             function removeActiveCaption () {
                 scope.vm.activeCaption = null;
+
+                scope.$broadcast('caption_reset');
             }
 
             /**
              * Handle click event on the card container
              * @param event
+             * @param startTime
              */
-            function containerClickHandler (event) {
+            function containerClickHandler (event, startTime) {
+                event.stopPropagation();
 
                 var playButton    = findElement('.jw-card-play-button')[0],
                     clickedOnPlay = playButton === event.target || playButton === event.target.parentNode;
 
                 if (angular.isFunction(scope.vm.onClick)) {
-                    scope.vm.onClick(scope.vm.item, clickedOnPlay);
+                    scope.vm.onClick(scope.vm.item, clickedOnPlay, startTime);
                 }
             }
 

--- a/js/core/directives/cardPoster.directive.js
+++ b/js/core/directives/cardPoster.directive.js
@@ -20,6 +20,7 @@
         THUMBNAIL_AUTOMATIC_TIMEOUT         = 500,
         THUMBNAIL_AUTOMATIC_INTERVAL        = 2300,
         CONTINUE_WATCHING_THUMBNAIL_QUALITY = 320,
+        SEARCH_THUMBNAIL_QUALITY            = 320,
         DEFAULT_CARD_THUMBNAIL_QUALITY      = 120,
         FEATURED_CARD_THUMBNAIL_QUALITY     = 320;
 
@@ -216,7 +217,7 @@
              * @param position
              */
             function showPositionThumbnail (url, position) {
-                thumbstrip.load(url, 320)
+                thumbstrip.load(url, SEARCH_THUMBNAIL_QUALITY)
                     .then(function (thumbnails) {
                         return thumbnails.find(function (item) {
                             return item.start <= position && item.end >= position;

--- a/js/core/directives/cardPoster.directive.js
+++ b/js/core/directives/cardPoster.directive.js
@@ -203,6 +203,22 @@
             }
 
             /**
+             * Show thumbnail closest to the item's position
+             * @param position
+             */
+            function showPositionThumbnail (position) {
+                thumbstrip
+                    .getThumbnails()
+                    .then(function (thumbnails) {
+                        return thumbnails.find(function (item) {
+                            return item.start < position && item.end >= position;
+                        });
+                    })
+                    .then(preloadImage)
+                    .then(showThumbnail);
+            }
+
+            /**
              * Create a poster element from the given thumb
              * @param {Object} thumb
              */

--- a/js/core/directives/cardPoster.directive.js
+++ b/js/core/directives/cardPoster.directive.js
@@ -75,6 +75,14 @@
                 thumbnailsTrack = getThumbnailsTrack();
                 feed            = dataStore.getFeed(jwCard.item.feedid);
 
+                scope.$on('caption_changed', function (event, data) {
+                    showPositionThumbnail(data.thumbnails, data.caption.time);
+                });
+
+                scope.$on('caption_reset', function () {
+                    showDefaultPoster();
+                });
+
                 // if the thumbnailTrack doesn't exist or the feed.enablePreview is false there is no need to continue
                 if (!thumbnailsTrack || !feed || !feed.enablePreview) {
                     return showDefaultPoster();
@@ -204,14 +212,14 @@
 
             /**
              * Show thumbnail closest to the item's position
+             * @param url
              * @param position
              */
-            function showPositionThumbnail (position) {
-                thumbstrip
-                    .getThumbnails()
+            function showPositionThumbnail (url, position) {
+                thumbstrip.load(url, 320)
                     .then(function (thumbnails) {
                         return thumbnails.find(function (item) {
-                            return item.start < position && item.end >= position;
+                            return item.start <= position && item.end >= position;
                         });
                     })
                     .then(preloadImage)
@@ -223,7 +231,6 @@
              * @param {Object} thumb
              */
             function showThumbnail (thumb) {
-
                 var posterElement,
                     x, y, w;
 

--- a/js/core/services/api.service.js
+++ b/js/core/services/api.service.js
@@ -136,7 +136,7 @@
                         var vtt = response.data;
 
                         return new Promise(function (resolve, reject) {
-                            const parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
+                            var parser = new WebVTT.Parser(window, WebVTT.StringDecoder());
                             var segments = [];
 
                             parser.onparsingerror = reject;

--- a/js/core/services/api.service.js
+++ b/js/core/services/api.service.js
@@ -98,7 +98,7 @@
          */
         this.patchItemWithCaptions = function (item, phrase) {
             if (!item.tracks) {
-                return Promise.resolve(item);
+                return $q.resolve(item);
             }
 
             var captionUrl  = null;
@@ -116,7 +116,7 @@
             });
 
             if (!captionUrl) {
-                return Promise.resolve(item);
+                return $q.resolve(item);
             }
 
             return findMatches(captionUrl, captionHits).then(function (matches) {
@@ -128,7 +128,7 @@
                     .then(function (response) {
                         var vtt = response.data;
 
-                        return new Promise(function (resolve, reject) {
+                        return $q(function (resolve, reject) {
                             var parser   = new WebVTT.Parser(window, WebVTT.StringDecoder());
                             var segments = [];
 
@@ -151,7 +151,6 @@
                             };
 
                             parser.parse(vtt);
-
                             parser.flush();
                         });
                     });

--- a/js/core/services/api.service.js
+++ b/js/core/services/api.service.js
@@ -85,6 +85,10 @@
 
             return getFeed(config.contentService + '/v2/playlists/' + searchPlaylist + '?search=' + phrase)
                 .then(function(feed) {
+                    if (!config.options.enableInVideoSearch) {
+                        return feed;
+                    }
+
                     var promises = [];
                     items = feed;
 
@@ -110,6 +114,10 @@
                     if (track.kind === 'captions' && /\.vtt$/.test(track.file)) {
                         captionUrl = track.file;
                         captionHits = track.hits;
+                    }
+
+                    if (track.kind === 'thumbnails') {
+                        item.thumbnails = track.file;
                     }
                 });
 

--- a/js/core/services/apiConsumer.service.js
+++ b/js/core/services/apiConsumer.service.js
@@ -163,6 +163,9 @@
          * Get search feed from the {@link jwShowcase.core.api api} and store it in the
          * {@link jwShowcase.core.dataStore dataStore}. Items not known by JW Showcase will be filtered out.
          *
+         * @param {string}  searchPhrase        The phrase that should be searched on
+         * @param {boolean} searchInCaptions    Should the search also include caption search results
+         *
          * @returns {Promise} A promise which will be resolved after the api request is finished.
          */
         this.getSearchFeed = function (searchPhrase) {

--- a/js/core/services/preload.service.js
+++ b/js/core/services/preload.service.js
@@ -155,7 +155,9 @@
                     '.jw-loading .jw-loading-icon .jwy-icon',
                     '.jw-skin-jw-showcase .jw-button-color:hover',
                     '.jw-skin-jw-showcase .jw-toggle.jw-off:hover',
-                    '.jw-skin-jw-showcase .jw-toggle:not(.jw-off)'
+                    '.jw-skin-jw-showcase .jw-toggle:not(.jw-off)',
+                    '.jw-theme-light .jw-card.jw-card-flag-default .jw-card-title .jw-card-title-matches',
+                    '.jw-theme-light .jw-card.jw-card-flag-default .jw-card-description span'
                 ];
 
             utils.addStylesheetRules([

--- a/js/core/services/preload.service.js
+++ b/js/core/services/preload.service.js
@@ -140,7 +140,9 @@
                     '.jw-card-watch-progress',
                     '.jw-card-toast-primary',
                     '.jw-offline-message',
-                    '.jw-skin-jw-showcase .jw-progress'
+                    '.jw-skin-jw-showcase .jw-progress',
+                    '.jw-card-in-video-search-timeline:hover',
+                    '.jw-card-in-video-search-timeline-dot:hover'
                 ],
                 colorClassNames = [
                     '.jw-button-default:hover',

--- a/js/search/controllers/search.controller.js
+++ b/js/search/controllers/search.controller.js
@@ -24,9 +24,9 @@
      * @ngdoc controller
      * @name jwShowcase.search.SearchController
      */
-    SearchController.$inject = ['$q', '$state', '$stateParams', 'platform', 'searchFeed', 'api'];
+    SearchController.$inject = ['$scope', '$q', '$state', '$stateParams', 'platform', 'searchFeed', 'api'];
 
-    function SearchController ($q, $state, $stateParams, platform, searchFeed, api) {
+    function SearchController ($scope, $q, $state, $stateParams, platform, searchFeed, api) {
 
         var vm               = this;
         var limit            = 10;
@@ -60,6 +60,8 @@
             addItemsToFeed(clone.playlist).then(function () {
                 vm.feed      = clone;
                 vm.searching = false;
+
+                $scope.$emit('$viewContentUpdated');
             });
         }
 
@@ -121,6 +123,8 @@
 
             addItemsToFeed(toBeAddedMediaItems).then(function () {
                 vm.feed.playlist = vm.feed.playlist.concat(toBeAddedMediaItems);
+            }).then(function () {
+                $scope.$emit('$viewContentUpdated');
             });
         }
     }

--- a/js/search/controllers/search.controller.js
+++ b/js/search/controllers/search.controller.js
@@ -45,14 +45,15 @@
          *
          * @param {jwShowcase.core.item}    item            Clicked item
          * @param {boolean}                 clickedOnPlay   Did the user clicked on the play button
+         * @param {number}                  [startTime]     Time to seek to once the video starts
          */
-        function cardClickHandler (item, clickedOnPlay) {
-
+        function cardClickHandler (item, clickedOnPlay, startTime) {
             $state.go('root.videoFromSearch', {
                 query:     $state.params.query,
                 mediaId:   item.mediaid,
                 slug:      item.$slug,
-                autoStart: clickedOnPlay || platform.isMobile
+                startTime: startTime,
+                autoStart: clickedOnPlay || platform.isMobile || typeof startTime !== 'undefined'
             });
         }
     }

--- a/js/search/search.module.js
+++ b/js/search/search.module.js
@@ -38,6 +38,9 @@
                 scrollTop:   'last',
                 persistent:  true,
                 history:     false,
+                params: {
+                    searchInCaptions: false
+                },
                 resolve:     {
                     searchFeed: ['$q', 'config', '$stateParams', 'apiConsumer', 'preload',
                         function ($q, config, $stateParams, apiConsumer) {

--- a/js/search/search.module.js
+++ b/js/search/search.module.js
@@ -32,14 +32,17 @@
 
         $stateProvider
             .state('root.search', {
-                url:         '/search/:query',
+                url:         '/search/:query?{searchInCaptions:boolean}',
                 controller:  'SearchController as vm',
                 templateUrl: 'views/search/search.html',
                 scrollTop:   'last',
                 persistent:  true,
                 history:     false,
                 params: {
-                    searchInCaptions: false
+                    searchInCaptions: {
+                        value:  false,
+                        squash: true
+                    }
                 },
                 resolve:     {
                     searchFeed: ['$q', 'config', '$stateParams', 'apiConsumer', 'preload',

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -52,6 +52,7 @@
             resumed              = false,
             started              = false,
             requestQualityChange = false,
+            startTime            = null,
             playlist             = [],
             levels,
             watchProgressItem,
@@ -135,6 +136,10 @@
                 }
             };
 
+            if ($state.params.startTime) {
+              startTime = $state.params.startTime;
+            }
+
             if (angular.isDefined(config.options.cast)) {
                 vm.playerSettings.cast = config.options.cast;
             }
@@ -194,7 +199,6 @@
          * Update controller
          */
         function update () {
-
             watchProgressItem = watchProgress.getItem(vm.item);
         }
 
@@ -219,7 +223,6 @@
                 .then(function () {
                     seo.update();
                 });
-
         }
 
         /**
@@ -440,6 +443,8 @@
                 requestQualityChange = false;
             }
 
+            performConditionalSeek();
+
             // watchProgress is disabled
             if (false === userSettings.settings.continueWatching || false === config.options.enableContinueWatching) {
                 return;
@@ -462,6 +467,14 @@
             lastPos = position;
 
             handleWatchProgress(position, event.duration);
+        }
+
+        function performConditionalSeek () {
+          if (startTime) {
+            player.seek(startTime);
+
+            startTime = null;
+          }
         }
 
         /**

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -202,6 +202,10 @@
             watchProgressItem = watchProgress.getItem(vm.item);
         }
 
+        /**
+         * Update the state silently. Meaning the $stateParams are updated with the new item, but the state isn't
+         * reloaded. This prevents the page from reloading and reinitialising the player.
+         */
         function updateStateSilently () {
 
             var stateParams = $state.params;
@@ -469,6 +473,9 @@
             handleWatchProgress(position, event.duration);
         }
 
+        /**
+         * Seek to time given in stateParams when set
+         */
         function performConditionalSeek () {
             if (startTime) {
                 player.seek(startTime);

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -137,7 +137,7 @@
             };
 
             if ($state.params.startTime) {
-              startTime = $state.params.startTime;
+                startTime = $state.params.startTime;
             }
 
             if (angular.isDefined(config.options.cast)) {
@@ -470,11 +470,11 @@
         }
 
         function performConditionalSeek () {
-          if (startTime) {
-            player.seek(startTime);
+            if (startTime) {
+                player.seek(startTime);
 
-            startTime = null;
-          }
+                startTime = null;
+            }
         }
 
         /**

--- a/js/video/video.module.js
+++ b/js/video/video.module.js
@@ -40,6 +40,7 @@
             },
             params:      {
                 autoStart: false,
+                startTime: null,
                 slug:      {
                     value:  null,
                     squash: true

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -56,6 +56,16 @@
 }
 
 //
+// jwButtonShowMore
+// --------------------------------
+
+.jw-button-show-more {
+    display: block;
+    position: relative;
+    margin: 0 80px;
+}
+
+//
 // jwButtonPlay
 // --------------------------------
 
@@ -136,5 +146,16 @@
     100% {
         transform: scale3d(1.5, 1.5, 1);
         opacity: 0;
+    }
+}
+
+//
+// mediaQueries
+// --------------------------------
+
+@include mobile-only() {
+
+    .jw-button-show-more {
+        margin: 0 15px;
     }
 }

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -204,6 +204,31 @@
             }
         }
     }
+
+    .jw-card-in-video-search-timeline {
+        @include transition(all 0.15s ease-in);
+        position: relative;
+        height: rem(2px);
+
+        .jw-card-in-video-search-timeline-dot {
+            $size: 13px;
+            $adjustSize: ($size - 1) / 2;
+
+            @include transform(translate(-$adjustSize, -$adjustSize));
+            @include transition(all 0.15s ease-in);
+
+            position: absolute;
+            height: rem($size);
+            width: rem($size);
+
+            border-radius: 50%;
+
+            &:hover {
+                $hoverSize: 18px;
+                transform: translate(-$adjustSize, -$adjustSize) scale($hoverSize / $size, $hoverSize / $size);
+            }
+        }
+    }
 }
 
 //

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -212,20 +212,20 @@
 
         .jw-card-in-video-search-timeline-dot {
             $size: 13px;
-            $adjustSize: ($size - 1) / 2;
+            $adjust-size: ($size - 1) / 2;
 
-            @include transform(translate(-$adjustSize, -$adjustSize));
+            @include transform(translate(-$adjust-size, -$adjust-size));
             @include transition(all 0.15s ease-in);
 
             position: absolute;
-            height: rem($size);
             width: rem($size);
+            height: rem($size);
 
             border-radius: 50%;
 
             &:hover {
-                $hoverSize: 18px;
-                transform: translate(-$adjustSize, -$adjustSize) scale($hoverSize / $size, $hoverSize / $size);
+                $hover-size: 18px;
+                transform: translate(-$adjust-size, -$adjust-size) scale($hover-size / $size, $hover-size / $size);
             }
         }
     }

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -22,6 +22,10 @@
         .jw-card-watchlist-button {
             @include transform(scale(0) !important);
         }
+
+        .jw-card-in-video-search-timeline {
+            display: none;
+        }
     }
 
     &-flag-hide-text {

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -31,6 +31,10 @@
     padding-top: $base-spacing-heading;
 }
 
+.center {
+    text-align: center;
+}
+
 //
 // mediaQueries
 // --------------------------------

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -80,6 +80,18 @@
             font-size: rem(16px);
         }
 
+        .jw-search-captions-toggle {
+            position: absolute;
+            top: 0;
+            right: 5px + 16px;
+            padding: 15px 10px;
+        }
+
+        .jw-search-captions-toggle-label {
+            font-size: rem(14px);
+            line-height: rem(22px);
+        }
+
         .jw-search-icon {
             position: absolute;
             left: 0;
@@ -116,6 +128,10 @@
             .jw-search-align {
                 height: 38px;
                 margin: 2px 10px;
+            }
+
+            .jw-search-captions-toggle {
+                padding: 8px 5px;
             }
 
             .jw-search-icon {

--- a/scss/components/_search.scss
+++ b/scss/components/_search.scss
@@ -38,6 +38,17 @@
                     opacity: 0;
                 }
             }
+
+            .jw-search-captions-toggle {
+                @include transition(opacity .3s ease 0.2s);
+                opacity: 0;
+            }
+        }
+
+        &.ng-hide-remove-active {
+            .jw-search-captions-toggle {
+                opacity: 1;
+            }
         }
 
         &.ng-hide-add {
@@ -58,6 +69,17 @@
 
             .jw-button:last-child {
                 display: none;
+            }
+
+            .jw-search-captions-toggle {
+                @include transition(opacity .3s ease 0s);
+                opacity: 1;
+            }
+        }
+
+        &.ng-hide-add-active {
+            .jw-search-captions-toggle {
+                opacity: 0;
             }
         }
 
@@ -85,6 +107,7 @@
             top: 0;
             right: 5px + 16px;
             padding: 15px 10px;
+            white-space: nowrap;
         }
 
         .jw-search-captions-toggle-label {
@@ -131,7 +154,7 @@
             }
 
             .jw-search-captions-toggle {
-                padding: 8px 5px;
+                display: none;
             }
 
             .jw-search-icon {

--- a/scss/mixins/_theme.scss
+++ b/scss/mixins/_theme.scss
@@ -63,7 +63,7 @@
 
     $card-menu-bg: $white !default;
 
-    $card-in-video-timeline-bg: $blue !default;
+    $card-in-video-timeline-bg: $secondary-color !default;
 
     // CardSlider
 

--- a/scss/mixins/_theme.scss
+++ b/scss/mixins/_theme.scss
@@ -63,7 +63,7 @@
 
     $card-menu-bg: $white !default;
 
-    $card-in-video-timeline-bg: #2d3b56 !default;
+    $card-in-video-timeline-bg: $blue !default;
 
     // CardSlider
 

--- a/scss/mixins/_theme.scss
+++ b/scss/mixins/_theme.scss
@@ -63,6 +63,8 @@
 
     $card-menu-bg: $white !default;
 
+    $card-in-video-timeline-bg: #2d3b56 !default;
+
     // CardSlider
 
     $card-slider-title-color: $secondary-color !default;
@@ -306,6 +308,36 @@
                 }
             }
         }
+
+        .jw-card-title .jw-card-title-matches {
+            font-weight: 400;
+            color: $primary-color;
+        }
+
+        .jw-card-description .jw-card-description-caption {
+            color: #979797;
+
+            span {
+                font-weight: 700;
+                color: $primary-color;
+            }
+        }
+
+        .jw-card-in-video-search-timeline {
+            background-color: $card-in-video-timeline-bg;
+
+            &:hover {
+                background-color: $primary-color;
+            }
+
+            .jw-card-in-video-search-timeline-dot {
+                background-color: $card-in-video-timeline-bg;
+
+                &:hover {
+                    background-color: $primary-color;
+                }
+            }
+        }
     }
 
     .jw-card.jw-card-flag-featured {
@@ -319,13 +351,11 @@
     // CardSlider
     // --------------------------------
 
-
     .jw-row:nth-child(2n+3) {
         .jw-card-slider {
             background-color: $card-slider-odd-bg-color;
         }
     }
-
 
     .jw-card-slider {
 

--- a/scss/mixins/_theme.scss
+++ b/scss/mixins/_theme.scss
@@ -310,16 +310,16 @@
         }
 
         .jw-card-title .jw-card-title-matches {
-            font-weight: 400;
             color: $primary-color;
+            font-weight: 400;
         }
 
         .jw-card-description .jw-card-description-caption {
-            color: #979797;
+            color: $gray;
 
             span {
-                font-weight: 700;
                 color: $primary-color;
+                font-weight: 700;
             }
         }
 

--- a/views/core/card.html
+++ b/views/core/card.html
@@ -31,7 +31,7 @@
         </div>
       </div>
     </div>
-    <div class="jw-card-in-video-search-timeline" ng-if="vm.inLineSearchEnabled">
+    <div class="jw-card-in-video-search-timeline" ng-if="vm.inVideoSearchEnabled">
       <div
         class="jw-card-in-video-search-timeline-dot"
         ng-repeat="caption in vm.item.captionMatches"

--- a/views/core/card.html
+++ b/views/core/card.html
@@ -22,9 +22,23 @@
       <div class="jw-card-info-mask">
         <a class="jw-card-title jw-card-text" tabindex="-1"></a>
         <div class="jw-card-description jw-card-text jw-markdown">
-          <jw-markdown ng-model="vm.item.description"></jw-markdown>
+          <div
+            ng-if="vm.activeCaption"
+            class="jw-card-description-caption"
+            ng-bind-html="vm.activeCaption.highlighted"
+          ></div>
+          <jw-markdown ng-if="!vm.activeCaption" ng-model="vm.item.description"></jw-markdown>
         </div>
       </div>
+    </div>
+    <div class="jw-card-in-video-search-timeline" ng-if="vm.inLineSearchEnabled">
+      <div
+        class="jw-card-in-video-search-timeline-dot"
+        ng-repeat="caption in vm.item.captionMatches"
+        ng-style="{left: (caption.time * 10 / vm.item.duration) * 100 + '%'}"
+        ng-mouseenter="vm.setActiveCaption(caption)"
+        ng-mouseleave="vm.removeActiveCaption()"
+      ></div>
     </div>
   </div>
 

--- a/views/core/card.html
+++ b/views/core/card.html
@@ -35,7 +35,8 @@
       <div
         class="jw-card-in-video-search-timeline-dot"
         ng-repeat="caption in vm.item.captionMatches"
-        ng-style="{left: (caption.time * 10 / vm.item.duration) * 100 + '%'}"
+        ng-style="{left: (caption.time / vm.item.duration) * 100 + '%'}"
+        ng-click="vm.containerClickHandler($event, caption.time)"
         ng-mouseenter="vm.setActiveCaption(caption)"
         ng-mouseleave="vm.removeActiveCaption()"
       ></div>

--- a/views/core/card.html
+++ b/views/core/card.html
@@ -39,6 +39,7 @@
         ng-click="vm.containerClickHandler($event, caption.time)"
         ng-mouseenter="vm.setActiveCaption(caption)"
         ng-mouseleave="vm.removeActiveCaption()"
+        ng-if="(caption.time / vm.item.duration) <= 1"
       ></div>
     </div>
   </div>

--- a/views/core/search.html
+++ b/views/core/search.html
@@ -5,6 +5,15 @@
       <input class="jw-search-input" type="text" placeholder="Type to search..."
           ng-model="vm.searchPhrase" ng-model-options="{ debounce: 500 }"
           ng-keyup="vm.searchInputKeyupHandler($event)" ng-change="vm.searchInputChangeHandler()"/>
+      <div class="jw-search-captions-toggle" ng-if="vm.config.options.enableInVideoSearch">
+          <span class="jw-search-captions-toggle-label">Include captions:</span>
+          <jw-toggle
+              aria-label="enable continue watching"
+              tabindex="0"
+              ng-model="vm.searchInCaptions"
+              ng-change="vm.toggleSearchInCaptions()"
+          ></jw-toggle>
+      </div>
       <jw-button class="jw-icon-button jw-button-close-search jw-button-default"
           ng-click="vm.closeSearchButtonClickHandler($event)"
           tabindex="0">

--- a/views/search/search.html
+++ b/views/search/search.html
@@ -1,7 +1,7 @@
 <jw-toolbar toolbar-class="jw-toolbar-subheader">Search results</jw-toolbar>
 
 <div class="has-jw-subheader">
-  <div class="jw-content" ng-if="!vm.feed.playlist.length">
+  <div class="jw-content" ng-if="!vm.feed.playlist.length && !vm.searching">
     <h4 class="jw-content-title">
       Nothing could be found, try changing your search phrase
     </h4>
@@ -9,10 +9,12 @@
 
   <jw-card-grid feed="vm.feed" on-card-click="vm.cardClickHandler" card-class-name="jw-lazy-load"
       cols="{xs:2, sm:2, md:3, lg:4, xl:5}"></jw-card-grid>
-  <jw-button
-      ng-if="vm.itemsLeft()"
-      ng-click="vm.showMoreClickHandler()"
-      class="jw-button-default jw-button-secondary jw-button-show-more">
-        Show more results...
-  </jw-button>
+  <div class="center">
+    <jw-button
+        ng-if="vm.itemsLeft()"
+        ng-click="vm.showMoreClickHandler()"
+        class="jw-button-secondary">
+      Show more results
+    </jw-button>
+  </div>
 </div>

--- a/views/search/search.html
+++ b/views/search/search.html
@@ -9,4 +9,10 @@
 
   <jw-card-grid feed="vm.feed" on-card-click="vm.cardClickHandler" card-class-name="jw-lazy-load"
       cols="{xs:2, sm:2, md:3, lg:4, xl:5}"></jw-card-grid>
+  <jw-button
+      ng-if="vm.itemsLeft()"
+      ng-click="vm.showMoreClickHandler()"
+      class="jw-button-default jw-button-secondary jw-button-show-more">
+        Show more results...
+  </jw-button>
 </div>


### PR DESCRIPTION
### Changes proposed in this pull request:

- [x] Poster change
- [x] Caption matches in description
- [x] Caption highlighted in description
- [x] Start playing at match time
- [x] When in-video search enabled, limit search results to 10 results and have "show more results" button at bottom (performance reasons)
- [x] Add "Include captions" toggle
- [x] Add feature tests

### To test:

- Add `"enableInVideoSearch": true,` to the options block in config.json
- Enter search term `caption`, `caption one`, or `caption two`.

Results are on the item, under property `captionMatches`. E.g. item.captionMatches
