### PR TITLE
Rename include captions to show caption matches

### DIFF
--- a/js/core/components/search.component.js
+++ b/js/core/components/search.component.js
@@ -52,15 +52,15 @@
 
         vm.config = config;
 
-        vm.searchPhrase     = '';
-        vm.searchBarActive  = false;
-        vm.searchInCaptions = false;
+        vm.searchPhrase       = '';
+        vm.searchBarActive    = false;
+        vm.showCaptionMatches = false;
 
-        vm.closeSearchButtonClickHandler = closeSearchButtonClickHandler;
-        vm.searchButtonClickHandler      = searchButtonClickHandler;
-        vm.searchInputKeyupHandler       = searchInputKeyupHandler;
-        vm.searchInputChangeHandler      = searchInputChangeHandler;
-        vm.toggleSearchInCaptions        = toggleSearchInCaptions;
+        vm.closeSearchButtonClickHandler   = closeSearchButtonClickHandler;
+        vm.searchButtonClickHandler        = searchButtonClickHandler;
+        vm.searchInputKeyupHandler         = searchInputKeyupHandler;
+        vm.searchInputChangeHandler        = searchInputChangeHandler;
+        vm.showCaptionMatchesChangeHandler = showCaptionMatchesChangeHandler;
 
         vm.$onInit = activate;
 
@@ -78,9 +78,9 @@
                     vm.searchBarActive = false;
                 }
                 else {
-                    vm.searchPhrase     = toParams.query.replace(/\+/g, ' ');
-                    vm.searchBarActive  = true;
-                    vm.searchInCaptions = toParams.searchInCaptions;
+                    vm.searchPhrase       = toParams.query.replace(/\+/g, ' ');
+                    vm.searchBarActive    = true;
+                    vm.showCaptionMatches = toParams.showCaptionMatches;
                 }
             });
         }
@@ -159,15 +159,15 @@
         function searchAndDisplayResults () {
 
             $state.go('root.search', {
-                query:            utils.slugify(vm.searchPhrase, '+'),
-                searchInCaptions: vm.searchInCaptions
+                query:              utils.slugify(vm.searchPhrase, '+'),
+                showCaptionMatches: vm.showCaptionMatches
             });
         }
 
         /**
          *  Handle search in captions toggle change
          */
-        function toggleSearchInCaptions () {
+        function showCaptionMatchesChangeHandler () {
 
             // prevent navigating to search state when search phrase is empty.
             if (vm.searchPhrase === '') {

--- a/js/core/directives/card.directive.js
+++ b/js/core/directives/card.directive.js
@@ -44,6 +44,7 @@
      */
     cardDirective.$inject = ['$animate', '$q', '$state', '$timeout', '$templateCache', '$compile', 'dataStore',
         'watchlist', 'utils', 'serviceWorker', 'config'];
+
     function cardDirective ($animate, $q, $state, $timeout, $templateCache, $compile, dataStore, watchlist, utils,
                             serviceWorker, config) {
 
@@ -65,8 +66,8 @@
             var isSearch            = $state.is('root.search');
             var enableInVideoSearch = config.options.enableInVideoSearch;
 
-            scope.vm.activeCaption        = null;
-            scope.vm.inVideoSearchEnabled = enableInVideoSearch && scope.vm.item.captionMatches && isSearch;
+            scope.vm.activeCaption      = null;
+            scope.vm.showCaptionMatches = enableInVideoSearch && scope.vm.item.captionMatches && isSearch;
 
             scope.vm.showToast              = showToast;
             scope.vm.closeMenu              = closeMenu;

--- a/js/search/controllers/search.controller.js
+++ b/js/search/controllers/search.controller.js
@@ -28,9 +28,9 @@
 
     function SearchController ($scope, $q, $state, $stateParams, platform, searchFeed, api) {
 
-        var vm               = this;
-        var limit            = 10;
-        var searchInCaptions = $stateParams.searchInCaptions && platform.screenSize() !== 'mobile';
+        var vm                 = this;
+        var limit              = 10;
+        var showCaptionMatches = $stateParams.showCaptionMatches && platform.screenSize() !== 'mobile';
 
         vm.cardClickHandler     = cardClickHandler;
         vm.showMoreClickHandler = showMoreClickHandler;
@@ -47,7 +47,7 @@
          * Initialize controller
          */
         function activate () {
-            if (!searchInCaptions) {
+            if (!showCaptionMatches) {
                 vm.feed      = searchFeed.clone();
                 vm.searching = false;
                 return;

--- a/js/search/search.module.js
+++ b/js/search/search.module.js
@@ -32,14 +32,14 @@
 
         $stateProvider
             .state('root.search', {
-                url:         '/search/:query?{searchInCaptions:boolean}',
+                url:         '/search/:query?{showCaptionMatches:boolean}',
                 controller:  'SearchController as vm',
                 templateUrl: 'views/search/search.html',
                 scrollTop:   'last',
                 persistent:  true,
                 history:     false,
                 params: {
-                    searchInCaptions: {
+                    showCaptionMatches: {
                         value:  false,
                         squash: true
                     }

--- a/views/core/card.html
+++ b/views/core/card.html
@@ -31,7 +31,7 @@
         </div>
       </div>
     </div>
-    <div class="jw-card-in-video-search-timeline" ng-if="vm.inVideoSearchEnabled">
+    <div class="jw-card-in-video-search-timeline" ng-if="vm.showCaptionMatches">
       <div
         class="jw-card-in-video-search-timeline-dot"
         ng-repeat="caption in vm.item.captionMatches"

--- a/views/core/search.html
+++ b/views/core/search.html
@@ -6,12 +6,12 @@
           ng-model="vm.searchPhrase" ng-model-options="{ debounce: 500 }"
           ng-keyup="vm.searchInputKeyupHandler($event)" ng-change="vm.searchInputChangeHandler()"/>
       <div class="jw-search-captions-toggle" ng-if="vm.config.options.enableInVideoSearch">
-          <span class="jw-search-captions-toggle-label">Include captions:</span>
+          <span class="jw-search-captions-toggle-label">Show caption matches:</span>
           <jw-toggle
               aria-label="enable continue watching"
               tabindex="0"
-              ng-model="vm.searchInCaptions"
-              ng-change="vm.toggleSearchInCaptions()"
+              ng-model="vm.showCaptionMatches"
+              ng-change="vm.showCaptionMatchesChangeHandler()"
           ></jw-toggle>
       </div>
       <jw-button class="jw-icon-button jw-button-close-search jw-button-default"


### PR DESCRIPTION
### Changes proposed in this pull request:

Rename misleading "Include captions" labels to "Show caption matches".
