### PR TITLE
Feature/showcase content only

### DIFF
--- a/js/core/services/apiConsumer.service.js
+++ b/js/core/services/apiConsumer.service.js
@@ -89,10 +89,11 @@
                 .getRecommendationsFeed(feedId, relatedMediaId)
                 .then(function (data) {
 
-                    // @todo create option to allow all pub items to show as related
-                    // data.playlist = dataStore.getItems().filter(function (item) {
-                    //     return data.playlist.findIndex(byMediaId(item.mediaid)) !== -1;
-                    // });
+                    if (config.options.showcaseContentOnly) {
+                        data.playlist = data.playlist.filter(function (item) {
+                            return !!dataStore.getItem(item.mediaid);
+                        });
+                    }
 
                     return data;
                 })
@@ -164,12 +165,12 @@
                 .getSearchFeed(config.searchPlaylist, searchPhrase)
                 .then(function (response) {
 
-                    var allItems = dataStore.getItems();
-
-                    // filter results to items loaded in Showcase when enableGlobalSearch is false
-                    feed.playlist = response.playlist.filter(function (item) {
-                        return config.options.enableGlobalSearch || allItems.find(byMediaId(item.mediaid));
-                    });
+                    // filter results to items loaded in Showcase when showcaseContentOnly is true
+                    if (config.options.showcaseContentOnly) {
+                        feed.playlist = response.playlist.filter(function (item) {
+                            return !!dataStore.getItem(item.mediaid);
+                        });
+                    }
 
                     // if enableInVideoSearch and requestCaptions are true, patch the first 10 items in the results
                     // with captions.

--- a/js/core/services/apiConsumer.service.js
+++ b/js/core/services/apiConsumer.service.js
@@ -87,19 +87,17 @@
 
             return api
                 .getRecommendationsFeed(feedId, relatedMediaId)
-                .then(function (data) {
+                .then(function (response) {
+
+                    feed.playlist = response.playlist;
 
                     if (config.options.showcaseContentOnly) {
-                        data.playlist = data.playlist.filter(function (item) {
+                        feed.playlist = feed.playlist.filter(function (item) {
                             return !!dataStore.getItem(item.mediaid);
                         });
                     }
 
-                    return data;
-                })
-                .then(function (data) {
-                    // merge data with feed
-                    return angular.merge(feed, data);
+                    return feed;
                 })
                 .catch(function (error) {
                     feed.$error     = error;
@@ -165,9 +163,12 @@
                 .getSearchFeed(config.searchPlaylist, searchPhrase)
                 .then(function (response) {
 
+                    // set playlist
+                    feed.playlist = response.playlist;
+
                     // filter results to items loaded in Showcase when showcaseContentOnly is true
                     if (config.options.showcaseContentOnly) {
-                        feed.playlist = response.playlist.filter(function (item) {
+                        feed.playlist = feed.playlist.filter(function (item) {
                             return !!dataStore.getItem(item.mediaid);
                         });
                     }

--- a/js/jwShowcase.module.js
+++ b/js/jwShowcase.module.js
@@ -33,6 +33,7 @@
         .value('config', {
             contentService: 'https://content.jwplatform.com',
             options:        {
+                showcaseContentOnly:       true,
                 enableContinueWatching:    true,
                 enableCookieNotice:        false,
                 enableFeaturedText:        true,

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -406,8 +406,20 @@
          */
         function onPlaylistItem (event) {
 
-            // search item in dataStore, fallback to item in event allowing global access.
-            var newItem = dataStore.getItem(event.item.mediaid) || event.item;
+            // search item in dataStore
+            var newItem = dataStore.getItem(event.item.mediaid);
+
+            // if item is not loaded in showcase
+            if (!newItem) {
+
+                // return when publisher has showcaseContentOnly set to true
+                if (config.options.showcaseContentOnly) {
+                    return;
+                }
+
+                // fallback to item given in event object
+                newItem = event.item;
+            }
 
             // return if item doesn't exist or its the same item
             if (newItem.mediaid === vm.item.mediaid) {

--- a/js/video/controllers/video.controller.js
+++ b/js/video/controllers/video.controller.js
@@ -104,7 +104,6 @@
             ph:             4,
             autostart:      $state.params.autoStart,
             playlist:       [],
-            related:        false,
             preload:        'metadata',
             sharing:        false,
             visualplaylist: false,
@@ -212,6 +211,11 @@
             if (!!window.cordova) {
                 vm.playerSettings.analytics.sdkplatform = platform.isAndroid ? 1 : 2;
                 vm.playerSettings.cast                  = false;
+            }
+
+            // disable related overlay if showcaseContentOnly is true.
+            if (config.options.showcaseContentOnly) {
+                vm.playerSettings.related = false;
             }
 
             // override player settings from config

--- a/js/video/video.module.js
+++ b/js/video/video.module.js
@@ -80,10 +80,25 @@
 
         /////////////////
 
-        resolveItem.$inject = ['$stateParams', 'dataStore', 'api', 'preload'];
+        resolveItem.$inject = ['$stateParams', '$q', 'dataStore', 'api', 'config', 'preload'];
 
-        function resolveItem ($stateParams, dataStore, api) {
-            return dataStore.getItem($stateParams.mediaId) || api.getItem($stateParams.mediaId);
+        function resolveItem ($stateParams, $q, dataStore, api, config) {
+
+            var item = dataStore.getItem($stateParams.mediaId);
+
+            // item not found in preloaded data.
+            if (!item) {
+
+                // show video not found error
+                if (config.options.showcaseContentOnly) {
+                    return $q.reject(new Error('Video not found'));
+                }
+
+                // get item from api.
+                return api.getItem($stateParams.mediaId);
+            }
+
+            return item;
         }
 
         resolveFeed.$inject = ['$stateParams', 'dataStore', 'apiConsumer', 'config', 'preload'];


### PR DESCRIPTION
### Changes proposed in this pull request:

**When `showcaseContentOnly` is true**

- Remove items that are not loaded in Showcase in recommendation and search feeds.
- Disable related overlay in the player.

**When `showcaseContentOnly` is false**

- Show all items from search and recommendation feeds.
- Allow publisher to enable related overlay via the player settings in Dashboard.
