### PR TITLE
Dismiss sidebar when clicking settings button on settings page

### DIFF
--- a/views/core/sidebar.html
+++ b/views/core/sidebar.html
@@ -69,7 +69,9 @@
       <jw-button
           class="jw-button-block jw-button-default"
           tabindex="0"
-          ui-sref="root.settings">
+          ui-sref="root.settings"
+          ui-sref-active="active"
+          ng-click="vm.itemClickHandler($event)">
             <span class="jw-button-label">Settings</span>
             <i class="jwy-icon jwy-icon-settings"></i>
         </jw-button>


### PR DESCRIPTION
### Changes proposed in this pull request:

Make sidebar disappear when already on Settings page and clicking on Settings link in sidebar.